### PR TITLE
Minor typo changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Michał Adamczyk
+Copyright (c) 2023 Michał Adamczyk
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Happy coding!
 
 ## License
 
-Copyright (c) 2022 Michał Adamczyk.
+Copyright (c) 2023 Michał Adamczyk.
 
 This project is licensed under the [MIT license](https://opensource.org/licenses/MIT).
 See [LICENSE](LICENSE) for more details.

--- a/example_test.go
+++ b/example_test.go
@@ -15,7 +15,7 @@ func ExampleLoad() {
 	}
 
 	var trans []string
-	for _, w := range []string{"ala", "ma", "kta"} {
+	for _, w := range []string{"ala", "ma", "kota"} {
 		t, err := g2p.Transcribe(w, false)
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
Change "kta" to "kota" in example test.
Change license dates.