### PR TITLE
Fix codecov upload in CI file

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -34,5 +34,8 @@ jobs:
     - name: Test
       run: go test -v -coverprofile coverage.txt -covermode atomic ./...
 
-    - name: Coverage
-      uses: codecov/codecov-action@v2.1.0
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [ '1.19', '1.21' ]
+        go-version: [ '1.21' ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
- Removed Go version 1.19 from CI matrix
- Fixed codecov upload action in CI file
